### PR TITLE
Content-Length is supposed to be bytes, not chars

### DIFF
--- a/lib/rack/livereload.rb
+++ b/lib/rack/livereload.rb
@@ -74,7 +74,7 @@ module Rack
                 headers["X-Rack-LiveReload"] = '1'
               end
 
-              content_length += line.length
+              content_length += line.bytesize
             end
 
             headers['Content-Length'] = content_length.to_s


### PR DESCRIPTION
Using length when there's UTF-8 chars in the response makes the browser to cut the page, because those chars have a length of 1 char but a bytesize of 2 bytes.

BTW Thank you for your work. This gem is been really helpful to me!
