### PR TITLE
Rack::Lock undefined for threadsafe Rails apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In `config/environments/development.rb`:
 
 ``` ruby
 MyApp::Application.configure do
-  config.middleware.insert_before(Rack::Lock, Rack::LiveReload)
+  config.middleware.insert_after(ActionDispatch::Static, Rack::LiveReload)
 
   # ...or, change some options...
 


### PR DESCRIPTION
When using `config.threadsafe!` there is no Rack::Lock middleware, so 

``` ruby
config.middleware.insert_before(Rack::Lock, Rack::LiveReload)
```

will not work. 

I'd suggest using

``` ruby
config.middleware.insert_after(ActionDispatch::Static, Rack::LiveReload)
```

instead - works for both cases.
