### PR TITLE
Added an option to change the port used by rack-livereload

### DIFF
--- a/js/livereload.js
+++ b/js/livereload.js
@@ -317,7 +317,7 @@ var Options;
 __options.Options = Options = (function() {
   function Options() {
     this.host = null;
-    this.port = 35729;
+    this.port = RACK_LIVERELOAD_PORT;
     this.snipver = null;
     this.ext = null;
     this.extver = null;

--- a/lib/rack/livereload.rb
+++ b/lib/rack/livereload.rb
@@ -3,15 +3,19 @@ require 'erb'
 module Rack
   class LiveReload
     LIVERELOAD_JS_PATH = '/__rack/livereload.js'
-    LIVERELOAD_LOCAL_URI = 'http://localhost:35729/livereload.js'
     HEAD_TAG_REGEX = /<head>|<head[^(er)][^<]*>/
 
     BAD_USER_AGENTS = [ %r{MSIE} ]
+
+    def livereload_local_uri
+      "http://localhost:#{@port}/livereload.js"
+    end
 
     attr_reader :app
 
     def initialize(app, options = {})
       @app, @options = app, options
+      @port = @options[:live_reload_port] || 35729
     end
 
     def use_vendored?
@@ -23,7 +27,8 @@ module Rack
         require 'net/http'
         require 'uri'
 
-        uri = URI.parse(LIVERELOAD_LOCAL_URI)
+
+        uri = URI.parse(livereload_local_uri)
 
         http = Net::HTTP.new(uri.host, uri.port)
         http.read_timeout = 1
@@ -71,7 +76,7 @@ module Rack
                 if use_vendored?
                   src = LIVERELOAD_JS_PATH.dup + "?host=#{host_to_use}"
                 else
-                  src = LIVERELOAD_LOCAL_URI.dup.gsub('localhost', host_to_use) + '?'
+                  src = livereload_local_uri.dup.gsub('localhost', host_to_use) + '?'
                 end
 
                 src << "&mindelay=#{@options[:min_delay]}" if @options[:min_delay]

--- a/skel/livereload.html.erb
+++ b/skel/livereload.html.erb
@@ -4,6 +4,7 @@
     <% if force_swf? %>
       WEB_SOCKET_FORCE_FLASH = true;
     <% end %>
+    RACK_LIVERELOAD_PORT = <%= @port %>;
   </script>
   <script type="text/javascript" src="/__rack/swfobject.js"></script>
   <script type="text/javascript" src="/__rack/web_socket.js"></script>

--- a/spec/rack/livereload_spec.rb
+++ b/spec/rack/livereload_spec.rb
@@ -12,7 +12,7 @@ describe Rack::LiveReload do
   let(:env) { {} }
   let(:options) { {} }
 
-  describe described_class::LIVERELOAD_LOCAL_URI do
+  describe "livereload local uri" do
     context 'does not exist' do
       before do
         stub_request(:any, 'localhost:35729/livereload.js').to_timeout
@@ -27,6 +27,16 @@ describe Rack::LiveReload do
       end
 
       it { should_not use_vendored }
+    end
+
+    context 'with custom port' do
+      let(:options) { {:live_reload_port => '12348'}}
+      context 'exists' do
+        before do
+          stub_request(:any, 'localhost:12348/livereload.js')
+        end
+        it { should_not use_vendored }
+      end
     end
 
     context 'specify vendored' do
@@ -120,7 +130,17 @@ describe Rack::LiveReload do
         body_dom.at_css("script:eq(4)")[:src].should include(described_class::LIVERELOAD_JS_PATH)
         body_dom.at_css("script:last-child")[:insert].should == "before"
       end
+
     end
+
+    describe "LIVERELOAD_PORT value" do
+      let(:options) { {:live_reload_port => 12345 }}
+      it "sets the variable at the top of the file" do
+        body.should include 'RACK_LIVERELOAD_PORT = 12345'
+      end
+    end
+
+
 
     context 'in header tags' do
       let(:page_html) { "<header class='hero'><h1>Just a normal header tag</h1></header>" }
@@ -140,7 +160,7 @@ describe Rack::LiveReload do
 
       it 'should add the LR livereload js script tag' do
         body.should include("script")
-        body.should include(described_class::LIVERELOAD_LOCAL_URI.gsub('localhost', 'host'))
+        body.should include(middleware.livereload_local_uri.gsub('localhost', 'host'))
       end
     end
 


### PR DESCRIPTION
This allows the javascript to work with a non default value for the
livereload port (specified with the port option in the guard command).

For example, in config/environments/development.rb in rails:
  config.middleware.insert_after(ActionDispatch::Static, Rack::LiveReload, :live_reload_port => 22351)
works with the following in the Guardfile:
  guard 'livereload', port: '22351' do
    ...
  end

This allows multiple guard livereload processes to operate at the same time without
conflicts.
