### PR TITLE
Handle Rails apps running on relative root

### DIFF
--- a/lib/rack/livereload.rb
+++ b/lib/rack/livereload.rb
@@ -77,8 +77,10 @@ module Rack
               if !headers['X-Rack-LiveReload'] && line['<head']
                 host_to_use = (@options[:host] || env['HTTP_HOST'] || 'localhost').gsub(%r{:.*}, '')
 
+                app_root = ENV['RAILS_RELATIVE_URL_ROOT'] || ''
+
                 if use_vendored?
-                  src = LIVERELOAD_JS_PATH.dup + "?host=#{host_to_use}"
+                  src = "#{app_root}#{LIVERELOAD_JS_PATH.dup}?host=#{host_to_use}"
                 else
                   src = livereload_local_uri.dup.gsub('localhost', host_to_use) + '?'
                 end

--- a/skel/livereload.html.erb
+++ b/skel/livereload.html.erb
@@ -5,8 +5,8 @@
       WEB_SOCKET_FORCE_FLASH = true;
     <% end %>
   </script>
-  <script type="text/javascript" src="/__rack/swfobject.js"></script>
-  <script type="text/javascript" src="/__rack/web_socket.js"></script>
+  <script type="text/javascript" src="<%= app_root %>/__rack/swfobject.js"></script>
+  <script type="text/javascript" src="<%= app_root %>/__rack/web_socket.js"></script>
 <% end %>
 <script type="text/javascript">
   RACK_LIVERELOAD_PORT = <%= @port %>;

--- a/spec/rack/livereload_spec.rb
+++ b/spec/rack/livereload_spec.rb
@@ -161,6 +161,15 @@ describe Rack::LiveReload do
         body_dom.at_css("script:last-child")[:insert].should == "before"
       end
 
+      context 'when a relative URL root is specified' do
+        before do
+          ENV['RAILS_RELATIVE_URL_ROOT'] = '/a_relative_path'
+        end
+
+        it 'should prepend the relative path to the script src' do
+          body_dom.at_css("script:eq(5)")[:src].should match(%r{^/a_relative_path/})
+        end
+      end
     end
 
     describe "LIVERELOAD_PORT value" do


### PR DESCRIPTION
rack-livereload was assuming that the rack app is running on the domain root. This isn't always the case, so this commit handles Rails apps running on a relative root. It's specific to Rails, so I'm not sure if it's something you're interested in for rack-livereload.
