### PR TITLE
Escape ampersands in the generated URL

### DIFF
--- a/lib/rack/livereload.rb
+++ b/lib/rack/livereload.rb
@@ -79,9 +79,9 @@ module Rack
                   src = livereload_local_uri.dup.gsub('localhost', host_to_use) + '?'
                 end
 
-                src << "&mindelay=#{@options[:min_delay]}" if @options[:min_delay]
-                src << "&maxdelay=#{@options[:max_delay]}" if @options[:max_delay]
-                src << "&port=#{@options[:port]}" if @options[:port]
+                src << "&amp;mindelay=#{@options[:min_delay]}" if @options[:min_delay]
+                src << "&amp;maxdelay=#{@options[:max_delay]}" if @options[:max_delay]
+                src << "&amp;port=#{@options[:port]}" if @options[:port]
 
                 template = ERB.new(::File.read(::File.expand_path('../../../skel/livereload.html.erb', __FILE__)))
 


### PR DESCRIPTION
I am useing livereload for web developing. And my HTML validator keep showing me a message that we should escape the ampersand on all my pages...
