### PR TITLE
Don't force iterating chunked (streamed) responses

### DIFF
--- a/lib/rack/livereload.rb
+++ b/lib/rack/livereload.rb
@@ -59,7 +59,9 @@ module Rack
       else
         status, headers, body = result = @app.call(env)
 
-        if (headers['Content-Type'] and headers['Content-Type']['text/event-stream']) or headers['Transfer-Encoding'] == 'chunked'
+        if (headers['Content-Type'] and headers['Content-Type']['text/event-stream']) or
+            headers['Transfer-Encoding'] == 'chunked' or
+            headers['Content-Disposition'] =~ %r{^inline}
           return result 
         end
 

--- a/spec/rack/livereload_spec.rb
+++ b/spec/rack/livereload_spec.rb
@@ -94,6 +94,21 @@ describe Rack::LiveReload do
     end
   end
 
+  context 'inline disposition' do
+    let(:body) { [ '<head></head>' ] }
+    let(:ret) { [ 200, { 'Content-Disposition' => 'inline; filename=my_inlined_file' }, body ] }
+
+    before do
+      app.stubs(:call).with(env).returns(ret)
+      body.expects(:close).never
+      body.stubs(:respond_to?).with(:close).returns(true)
+    end
+
+    it 'should pass through' do
+      middleware.call(env).should == ret
+    end
+  end
+
   context 'unknown Content-Type' do
     let(:ret) { [ 200, {}, [ 'hey ho' ] ] }
 


### PR DESCRIPTION
Was tearing my hair out trying to work out why Rails was buffering my entire (ostensibly) streamed response.  Finally realized that rack-livereload was screwing me over.  Don't do that, rack-livereload.

And while we're at it, don't mess with inlined content either, since the chunked header might not get there before rack-livereload in the stack.
