### PR TITLE
pass images through

### DIFF
--- a/lib/rack/livereload.rb
+++ b/lib/rack/livereload.rb
@@ -59,7 +59,8 @@ module Rack
       else
         status, headers, body = result = @app.call(env)
 
-        if (headers['Content-Type'] and headers['Content-Type']['text/event-stream']) or
+        if (headers['Content-Type'] and (headers['Content-Type']['text/event-stream'] or
+                                         headers['Content-Type'][%r{^image/}])) or
             headers['Transfer-Encoding'] == 'chunked' or
             headers['Content-Disposition'] =~ %r{^inline}
           return result 

--- a/spec/rack/livereload_spec.rb
+++ b/spec/rack/livereload_spec.rb
@@ -53,10 +53,25 @@ describe Rack::LiveReload do
   end
 
   context 'not text/html' do
-    let(:ret) { [ 200, { 'Content-Type' => 'image/png' }, [ '<head></head>' ] ] }
+    let(:ret) { [ 200, { 'Content-Type' => 'application/pdf' }, [ '<head></head>' ] ] }
 
     before do
       app.stubs(:call).with(env).returns(ret)
+    end
+
+    it 'should pass through' do
+      middleware.call(env).should == ret
+    end
+  end
+
+  context 'image/png' do
+    let(:body) { [ '<head></head>' ] }
+    let(:ret) { [ 200, { 'Content-Type' => 'image/png' }, body ] }
+
+    before do
+      app.stubs(:call).with(env).returns(ret)
+      body.expects(:close).never
+      body.stubs(:respond_to?).with(:close).returns(true)
     end
 
     it 'should pass through' do


### PR DESCRIPTION
Allows dragonfly to work properly and not complain about TempObject.closed.
