### PR TITLE
Reference the top-level Timeout, to avoid conflicts with Rack::Timeout

### DIFF
--- a/lib/rack/livereload/body_processor.rb
+++ b/lib/rack/livereload/body_processor.rb
@@ -45,7 +45,7 @@ module Rack
           begin
             http.send_request('GET', uri.path)
             @use_vendored = false
-          rescue Timeout::Error, Errno::ECONNREFUSED, EOFError
+          rescue ::Timeout::Error, Errno::ECONNREFUSED, EOFError
             @use_vendored = true
           rescue => e
             $stderr.puts e.inspect


### PR DESCRIPTION
Otherwise we get: `#<NameError: uninitialized constant Rack::Timeout::Error>`
