### PR TITLE
fix README reference to changing port

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ MyApp::Application.configure do
     Rack::Lock, Rack::LiveReload,
     :min_delay => 500,
     :max_delay => 10000,
-    :port => 56789,
+    :live_reload_port => 56789,
     :host => 'myhost.cool.wow',
     :ignore => [ %r{dont/modify\.html$} ]
   )


### PR DESCRIPTION
#25 forgot to update README.md to reference the new `live_reload_port` option.
