### PR TITLE
parse fullpath for ignore

### DIFF
--- a/lib/rack/livereload/processing_skip_analyzer.rb
+++ b/lib/rack/livereload/processing_skip_analyzer.rb
@@ -28,7 +28,8 @@ module Rack
       end
 
       def ignored?
-        @options[:ignore] and @options[:ignore].any? { |filter| @env['PATH_INFO'][filter] }
+        path = @env['QUERY_STRING'].empty? ? @env['PATH_INFO'] : "#{@env['PATH_INFO']}?#{@env['QUERY_STRING']}"
+        @options[:ignore] and @options[:ignore].any? { |filter| path[filter] }
       end
 
       def bad_browser?

--- a/spec/rack/livereload/processing_skip_analyzer_spec.rb
+++ b/spec/rack/livereload/processing_skip_analyzer_spec.rb
@@ -22,13 +22,13 @@ describe Rack::LiveReload::ProcessingSkipAnalyzer do
     let(:options) { { :ignore => [ %r{file} ] } }
 
     context 'path contains ignore pattern' do
-      let(:env) { { 'PATH_INFO' => '/this/file' } }
+      let(:env) { { 'PATH_INFO' => '/this/file', 'QUERY_STRING' => '' } }
 
       it { should be_ignored }
     end
 
     context 'root path' do
-      let(:env) { { 'PATH_INFO' => '/' } }
+      let(:env) { { 'PATH_INFO' => '/', 'QUERY_STRING' => '' } }
 
       it { should_not be_ignored }
     end
@@ -56,7 +56,8 @@ describe Rack::LiveReload::ProcessingSkipAnalyzer do
 
   describe '#ignored?' do
     let(:path_info) { 'path info' }
-    let(:env) { { 'PATH_INFO' => path_info } }
+    let(:query_string) { 'query_string' }
+    let(:env) { { 'PATH_INFO' => path_info, 'QUERY_STRING' => query_string } }
 
     context 'no ignore set' do
       it { should_not be_ignored }
@@ -64,6 +65,12 @@ describe Rack::LiveReload::ProcessingSkipAnalyzer do
 
     context 'ignore set' do
       let(:options) { { :ignore => [ %r{#{path_info}} ] } }
+
+      it { should be_ignored }
+    end
+
+    context 'ignore set including query_string' do
+      let(:options) { { :ignore => [ %r{#{path_info}\?#{query_string}} ] } }
 
       it { should be_ignored }
     end


### PR DESCRIPTION
Added to support query strings via the `:ignore` option e.g. `/path/to/html?reload=false`

(some travis tests are failing because dependancies don't support the various ruby versions being tested)