### PR TITLE
Catch an IOError that happens on Ruby 2.0

### DIFF
--- a/lib/rack/livereload/body_processor.rb
+++ b/lib/rack/livereload/body_processor.rb
@@ -45,7 +45,7 @@ module Rack
           begin
             http.send_request('GET', uri.path)
             @use_vendored = false
-          rescue ::Timeout::Error, Errno::ECONNREFUSED, EOFError
+          rescue ::Timeout::Error, Errno::ECONNREFUSED, EOFError, IOError
             @use_vendored = true
           rescue => e
             $stderr.puts e.inspect


### PR DESCRIPTION
Would get a #<IOError: closed stream> error when running in my MRI 2.0 environment (works fine on 1.9.3). Either there's a Ruby change in the `net/http` works or something else in the `guard-livereload` server (I'm using an old 1.0.3 here), but this looks to work for me.
