### PR TITLE
Set the protocol of the livereload source

### DIFF
--- a/lib/rack/livereload/body_processor.rb
+++ b/lib/rack/livereload/body_processor.rb
@@ -9,8 +9,12 @@ module Rack
 
       attr_reader :content_length, :new_body, :livereload_added
 
+      def protocol
+        @options[:protocol] || "http"
+      end
+
       def livereload_local_uri
-        "http://localhost:#{@options[:live_reload_port]}/livereload.js"
+        "#{protocol}://localhost:#{@options[:live_reload_port]}/livereload.js"
       end
 
       def initialize(body, options)


### PR DESCRIPTION
This will allow a user to serve livereload from HTTPS
(Also requires using the :source => :livereload option)