### PR TITLE
Inject js code only into valid html head tags

### DIFF
--- a/rack-livereload.gemspec
+++ b/rack-livereload.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   # specify any dependencies here; for example:
   s.add_development_dependency "rspec"
+  s.add_development_dependency "rspec-its"
   s.add_development_dependency "cucumber"
   s.add_development_dependency "httparty"
   s.add_development_dependency "sinatra"

--- a/spec/rack/livereload/body_processor_spec.rb
+++ b/spec/rack/livereload/body_processor_spec.rb
@@ -2,23 +2,6 @@ require 'spec_helper'
 require 'nokogiri'
 
 describe Rack::LiveReload::BodyProcessor do
-  describe 'head tag regex' do
-    let(:regex) { described_class::HEAD_TAG_REGEX }
-    subject { regex }
-
-    it { should be_kind_of(Regexp) }
-
-    it 'only picks a valid <head> tag' do
-      regex.match("<head></head>").to_s.should eq('<head>')
-      regex.match("<head><title></title></head>").to_s.should eq('<head>')
-      regex.match("<head attribute='something'><title></title></head>").to_s.should eq("<head attribute='something'>")
-    end
-
-    it 'responds false when no head tag' do
-      regex.match("<header></header>").should be_false
-    end
-  end
-
   let(:processor) { described_class.new(body, options) }
   let(:body) { [ page_html ] }
   let(:options) { {} }
@@ -140,6 +123,14 @@ describe Rack::LiveReload::BodyProcessor do
       it 'should not add the livereload js' do
         body_dom.at_css("header")[:class].should == 'hero'
         body_dom.css('script').should be_empty
+      end
+    end
+
+    context 'in html content areas' do
+      let(:page_html) { "<script type='text/template'><head></head></script> <!-- <head></head> --> <xmp><head></head></xmp>" }
+
+      it 'should not add the livereload js' do
+        processed_body.should == "<script type=\"text/template\">\n  <head/>\n</script> <!-- <head></head> --> <xmp>\n  <head/>\n</xmp>"
       end
     end
 

--- a/spec/rack/livereload/processing_skip_analyzer_spec.rb
+++ b/spec/rack/livereload/processing_skip_analyzer_spec.rb
@@ -14,7 +14,7 @@ describe Rack::LiveReload::ProcessingSkipAnalyzer do
 
   describe '#skip_processing?' do
     it "should skip processing" do
-      subject.skip_processing?.should be_true
+      subject.skip_processing?.should be_truthy
     end
   end
 

--- a/spec/rack/livereload_spec.rb
+++ b/spec/rack/livereload_spec.rb
@@ -20,7 +20,7 @@ describe Rack::LiveReload do
     end
 
     it 'should return the js file' do
-      middleware._call(env).should be_true
+      middleware._call(env).should be_truthy
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,14 @@
 require 'mocha/api'
 require 'webmock/rspec'
+require 'rspec/its'
 
 require 'rack-livereload'
 
 RSpec.configure do |c|
+  c.expect_with :rspec do |config|
+    config.syntax = :should
+  end
+
   c.mock_with :mocha
 end
 


### PR DESCRIPTION
This addresses issue #60 

I think the idea was that https://github.com/johnbintz/rack-livereload/blob/master/lib/rack/livereload/body_processor.rb#L73 would prevent this issue from occurring.
However RACK can pass the entire document as a single line. So when entering this section of code the @livereload_added would still be false and then it would proceed to replace all occurrences of the text `<head>` with the injected code.

This version pull request uses proper XML parsing to find the `<head>` element.
