### PR TITLE
Only injects code into the first occurrence of <head> tags

### DIFF
--- a/lib/rack/livereload/body_processor.rb
+++ b/lib/rack/livereload/body_processor.rb
@@ -71,7 +71,7 @@ module Rack
 
         @new_body.each do |line|
           if !@livereload_added && line['<head']
-            line.gsub!(HEAD_TAG_REGEX) { |match| %{#{match}#{template.result(binding)}} }
+            line.sub!(HEAD_TAG_REGEX) { |match| %{#{match}#{template.result(binding)}} }
 
             @livereload_added = true
           end
@@ -109,4 +109,3 @@ module Rack
     end
   end
 end
-

--- a/rack-livereload.gemspec
+++ b/rack-livereload.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   # specify any dependencies here; for example:
   s.add_development_dependency "rspec"
+  s.add_development_dependency "rspec-its"
   s.add_development_dependency "cucumber"
   s.add_development_dependency "httparty"
   s.add_development_dependency "sinatra"

--- a/spec/rack/livereload/body_processor_spec.rb
+++ b/spec/rack/livereload/body_processor_spec.rb
@@ -15,7 +15,7 @@ describe Rack::LiveReload::BodyProcessor do
     end
 
     it 'responds false when no head tag' do
-      regex.match("<header></header>").should be_false
+      regex.match("<header></header>").should be_falsey
     end
   end
 
@@ -140,6 +140,14 @@ describe Rack::LiveReload::BodyProcessor do
       it 'should not add the livereload js' do
         body_dom.at_css("header")[:class].should == 'hero'
         body_dom.css('script').should be_empty
+      end
+    end
+
+    context 'in document with more than one reference to a head tag' do
+      let(:page_html) { "<head><head><!-- <head></head> -->" }
+
+      it 'should not add the livereload js' do
+        processed_body.should include == "<!-- <head></head> -->"
       end
     end
 

--- a/spec/rack/livereload/processing_skip_analyzer_spec.rb
+++ b/spec/rack/livereload/processing_skip_analyzer_spec.rb
@@ -14,7 +14,7 @@ describe Rack::LiveReload::ProcessingSkipAnalyzer do
 
   describe '#skip_processing?' do
     it "should skip processing" do
-      subject.skip_processing?.should be_true
+      subject.skip_processing?.should be_truthy
     end
   end
 

--- a/spec/rack/livereload_spec.rb
+++ b/spec/rack/livereload_spec.rb
@@ -20,7 +20,7 @@ describe Rack::LiveReload do
     end
 
     it 'should return the js file' do
-      middleware._call(env).should be_true
+      middleware._call(env).should be_truthy
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,14 @@
 require 'mocha/api'
 require 'webmock/rspec'
+require 'rspec/its'
 
 require 'rack-livereload'
 
 RSpec.configure do |c|
+  c.expect_with :rspec do |config|
+    config.syntax = :should
+  end
+
   c.mock_with :mocha
 end
 


### PR DESCRIPTION
This partially addresses issue #60

I think the idea was that https://github.com/johnbintz/rack-livereload/blob/master/lib/rack/livereload/body_processor.rb#L73 would prevent this issue from occurring.
However RACK can pass the entire document as a single line. So when entering this section of code the @livereload_added would still be false and then it would proceed to replace all occurrences of the text `<head>` with the injected code.

This fix simply makes sure we replace only the first occurrence of `<head>` as I believe was intended by the check found on line 73 of the body_processor.rb.
