### PR TITLE
Only inject JS into the first instance of <head>.

### DIFF
--- a/lib/rack/livereload/body_processor.rb
+++ b/lib/rack/livereload/body_processor.rb
@@ -71,7 +71,7 @@ module Rack
 
         @new_body.each do |line|
           if !@livereload_added && line['<head']
-            line.gsub!(HEAD_TAG_REGEX) { |match| %{#{match}#{template.result(binding)}} }
+            line.sub!(HEAD_TAG_REGEX) { |match| %{#{match}#{template.result(binding)}} }
 
             @livereload_added = true
           end

--- a/spec/rack/livereload/body_processor_spec.rb
+++ b/spec/rack/livereload/body_processor_spec.rb
@@ -143,6 +143,14 @@ describe Rack::LiveReload::BodyProcessor do
       end
     end
 
+    context 'in inline javascript containing markup' do
+      let(:page_html) { '<head></head><script>var html="<head></head>";</script>' }
+
+      it 'should not add the livereload js' do
+        processed_body.should include('var html="<head></head>"')
+      end
+    end
+
     context 'not vendored' do
       before do
         processor.stubs(:use_vendored?).returns(false)


### PR DESCRIPTION
rack-livereload injects code into every instance of `<head>` encountered, instead of just the first. This causes issues with inline Javascript containing markup.

```
<script>
var html="<head></head>";
</script>
```