### PR TITLE
Fixed ignore to work with full URI

### DIFF
--- a/lib/rack/livereload/processing_skip_analyzer.rb
+++ b/lib/rack/livereload/processing_skip_analyzer.rb
@@ -28,8 +28,9 @@ module Rack
       end
 
       def ignored?
-        path = @env['QUERY_STRING'].empty? ? @env['PATH_INFO'] : "#{@env['PATH_INFO']}?#{@env['QUERY_STRING']}"
-        @options[:ignore] and @options[:ignore].any? { |filter| path[filter] }
+        @options[:ignore] and @options[:ignore].any? do |filter|
+          @env['REQUEST_URI'][filter]
+        end
       end
 
       def bad_browser?

--- a/spec/rack/livereload/processing_skip_analyzer_spec.rb
+++ b/spec/rack/livereload/processing_skip_analyzer_spec.rb
@@ -22,13 +22,13 @@ describe Rack::LiveReload::ProcessingSkipAnalyzer do
     let(:options) { { :ignore => [ %r{file} ] } }
 
     context 'path contains ignore pattern' do
-      let(:env) { { 'PATH_INFO' => '/this/file', 'QUERY_STRING' => '' } }
+      let(:env) { { 'REQUEST_URI' => '/this/file', 'QUERY_STRING' => '' } }
 
       it { should be_ignored }
     end
 
     context 'root path' do
-      let(:env) { { 'PATH_INFO' => '/', 'QUERY_STRING' => '' } }
+      let(:env) { { 'REQUEST_URI' => '/', 'QUERY_STRING' => '' } }
 
       it { should_not be_ignored }
     end
@@ -55,22 +55,21 @@ describe Rack::LiveReload::ProcessingSkipAnalyzer do
   end
 
   describe '#ignored?' do
-    let(:path_info) { 'path info' }
-    let(:query_string) { 'query_string' }
-    let(:env) { { 'PATH_INFO' => path_info, 'QUERY_STRING' => query_string } }
+    let(:request_uri) { 'request_path?query_string' }
+    let(:env) { { 'REQUEST_URI' => request_uri } }
 
     context 'no ignore set' do
       it { should_not be_ignored }
     end
 
     context 'ignore set' do
-      let(:options) { { :ignore => [ %r{#{path_info}} ] } }
+      let(:options) { { :ignore => [ /request_path/ ] } }
 
       it { should be_ignored }
     end
 
     context 'ignore set including query_string' do
-      let(:options) { { :ignore => [ %r{#{path_info}\?#{query_string}} ] } }
+      let(:options) { { :ignore => [ /query_string/ ] } }
 
       it { should be_ignored }
     end


### PR DESCRIPTION
Hello!

I don't know exactly why it didn't work with [teaspoon](https://github.com/modeset/teaspoon). But I've made some refactor and it works now.

So, env['REQUEST_URI'] refers to full URI path and it must be used instead of env['PATH_INFO'].